### PR TITLE
Fix MacOS platform name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.1] - 2020-11-03
+
+### Fixes
+
+* Change macOS platform name in `meta/main.yml` to something that Galaxy expects.
+
 ## [0.1.0] - 2020-11-03
 
 * Initial commit

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
         - xenial
         - bionic
         - focal
-    - name: MacOS
+    - name: macOS
       versions:
         - 10.15
   galaxy_tags:


### PR DESCRIPTION
This change fixes the platform name used for macOS to the one that
Galaxy expects.