### PR TITLE
Ensure idempotency when checking for shell rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.1] - 2020-11-03
+
+### Fixes
+
+* Pass `create: true` when amending the shell rc file instead of relying on a separate `file` module
+  call to ensure that the file exists. This makes the role properly idempotent and slightly simpler.
+
 ## [0.1.0] - 2020-11-03
 
 * Initial commit

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,6 +12,7 @@ provisioner:
   hosts: test_kitchen
   role_name: profile_d
   ansible_sudo: false
+  idempotency_test: true
   # Don't install via Ansible omnibus
   require_ansible_omnibus: false
   # Don't install via OS package manager. This is broken on Focal

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,10 +25,6 @@
 
 - name: Configure ZSH
   block:
-    - name: Ensure ~/.zshrc exists
-      ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/.zshrc"
-        state: touch
     - name: Add bashcompinit for ZSH
       ansible.builtin.copy:
         backup: false
@@ -38,6 +34,7 @@
     - name: Amend ~/.zshrc to load ~/.profile.d
       ansible.builtin.blockinfile:
         backup: true
+        create: true
         block: |
           # Source profile.d files
           for f in $(ls "$HOME/.profile.d/"); do
@@ -49,23 +46,17 @@
         path: "{{ ansible_user_dir }}/.zshrc"
   when: '"zsh" in profile_d_shell'
 
-
-- name: Configure Bash
-  block:
-    - name: Ensure ~/.bashrc exists
-      ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/.bashrc"
-        state: touch
-    - name: Amend ~/.bashrc to load ~/.profile.d
-      ansible.builtin.blockinfile:
-        backup: true
-        block: |
-          # Source profile.d files
-          for f in $(ls "$HOME/.profile.d/"); do
-            # Use ls instead of find to avoid relying on external binaries
-            source "$HOME/.profile.d/$f"
-          done
-        insertafter: EOF
-        marker: "# {mark} PROFILE.D BLOCK"
-        path: "{{ ansible_user_dir }}/.bashrc"
+- name: Amend ~/.bashrc to load ~/.profile.d
+  ansible.builtin.blockinfile:
+    backup: true
+    create: true
+    block: |
+      # Source profile.d files
+      for f in $(ls "$HOME/.profile.d/"); do
+        # Use ls instead of find to avoid relying on external binaries
+        source "$HOME/.profile.d/$f"
+      done
+    insertafter: EOF
+    marker: "# {mark} PROFILE.D BLOCK"
+    path: "{{ ansible_user_dir }}/.bashrc"
   when: '"bash" in profile_d_shell'


### PR DESCRIPTION
This change makes the role properly idempotent by removing a call to the
`ansible.builtin.file` module and using the capabilities of the
`ansible.builtin.blockinfile` module to create the destination file if
it does not already exist.

Fixes #4 